### PR TITLE
stuff actions into nested property for isolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,14 @@ module.exports = function stateMixin(Reflux) {
   }
 
   function attachAction(options, actionName) {
-    if (this[actionName]) {
+    this.__actions__ = this.__actions__ || {};
+    if (this.__actions__[actionName]) {
       console.warn(
           'Not attaching event ' + actionName + '; key already exists'
       );
       return;
     }
-    this[actionName] = Reflux.createAction(options);
+    this.__actions__[actionName] = Reflux.createAction(options);
   }
 
   return {
@@ -33,7 +34,7 @@ module.exports = function stateMixin(Reflux) {
       for (var key in state) {
         if (state.hasOwnProperty(key)) {
           if (this.state[key] !== state[key]) {
-            this[key].trigger(state[key]);
+            this.__actions__[key].trigger(state[key]);
             changed = true;
           }
         }
@@ -82,7 +83,7 @@ module.exports = function stateMixin(Reflux) {
                   me.setState(utils.object([key], [v]));
                 }
               }),
-              listener = noKey ? store : store[key];
+              listener = noKey ? store : store.__actions__[key];
           this.listenTo(listener, cb);
         },
         componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount
@@ -90,5 +91,3 @@ module.exports = function stateMixin(Reflux) {
     }
   }
 };
-
-


### PR DESCRIPTION
When I loaded this mixin into my application, I saw a bunch of the following warning onload...

```
Not attaching event isPlaying; key already exists
```

...then the following error when I tried calling an action...

```
TypeError: this[key].trigger is not a function
```

What I ended up discovering is that this mixin creates new actions embedded in the store. In my case, they were colliding with functions that already exist in my store.

See a (slimmed down) example of my store:

``` javascript
const Reflux = require('reflux');
const StateMixin = require('reflux-state-mixin')(Reflux);
const PlayerActions = require('../actions/PlayerActions');

const PlayerStore = Reflux.createStore({
    mixins: [StateMixin],
    listenables: [PlayerActions],

    getInitialState() {
        return {
            isPlaying: false
        };
    },

    isPlaying() {
        return this.state.isPlaying;
    },

    onPlay() {
        this.setState({isPlaying: true});
    },

    onPause() {
        this.setState({isPlaying: false});
    }
});

module.exports = PlayerStore;
```

So, in this case, it wanted to create an action for `isPlaying` and assign it to `isPlaying()`, but it's already a function.

For this change, I isolated all the created actions under a new `__actions__` property.
