### PR TITLE
support 0.2.1x versions of reflux

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "ISC",
   "dependencies": {},
   "peerDependencies": {
-    "reflux": ">=0.2.5 <0.4.0"
+    "reflux": ">=0.2.1 <0.4.0"
   },
   "homepage": "https://github.com/yonatanmn/reflux-state-mixin",
   "readmeFilename": "README.md",


### PR DESCRIPTION
The current supported reflux versions `>=0.2.5 <0.4.0` leave out the newer `>0.2.10` versions.

This forces npm to install the newest version it can, which is `0.3.0`, which I can't upgrade to yet.

This might not be ideal because it will include versions that may not be supported, but due to the confusion with the versioning for reflux I don't know if there's really a better solution.
